### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,6 +6,11 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   greet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MStarRobotics/RSS2025/security/code-scanning/1](https://github.com/MStarRobotics/RSS2025/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow:
- `contents: read` is required to read repository contents.
- `issues: write` is required to interact with issues (e.g., searching and recognizing milestones).
- `pull-requests: write` is required to interact with pull requests (e.g., adding labels).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `greet` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
